### PR TITLE
Effectively Remove No Ads Staking Benefit

### DIFF
--- a/src/app/client_config.js
+++ b/src/app/client_config.js
@@ -672,7 +672,7 @@ export const SITE_DESCRIPTION =
 export const SUPPORT_EMAIL = 'support@' + APP_DOMAIN;
 
 // Revive Ads
-export const NO_ADS_STAKE_THRESHOLD = 500000;
+export const NO_ADS_STAKE_THRESHOLD = 50000000000;
 export const REVIVE_ADS = {
     header_banner: {
         zoneId: '1848',


### PR DESCRIPTION
Changed NO_ADS_STAKE to 50,000,000,000 to help deliver advertising to all users.